### PR TITLE
Move Account data type to AccountData from live-common

### DIFF
--- a/apps/client-test/src/index.ts
+++ b/apps/client-test/src/index.ts
@@ -9,46 +9,50 @@ async function main() {
 
   let version: number | undefined;
 
-  const client = new WalletSyncClient({
-    url: "http://localhost:3000",
-    pollFrequencyMs: 5000,
-    auth,
-    clientInfo: "test/0.0.1"
-  },
-  {
-    onVersionUpdate: (newVersion) => { version = newVersion },
-    getVersion: () => version,
-  });
+  const client = new WalletSyncClient(
+    {
+      url: "http://localhost:3000",
+      pollFrequencyMs: 5000,
+      auth,
+      clientInfo: "test/0.0.1",
+    },
+    {
+      onVersionUpdate: (newVersion) => {
+        version = newVersion;
+      },
+      getVersion: () => version,
+    }
+  );
 
   client.observable().subscribe((walletData) => {
     // eslint-disable-next-line no-console
     console.log("new wallet data: ", walletData);
   });
 
-  const result = await client.saveData(
-    [
-      {
-        type: "address",
-        currencyId: "ethereum",
-        name: "Ethereum 1",
-        address: "0x053A031856b23A823b71e032C92b1599Ac1cc3F2",
-        seedId:
-          "041d35ac3e26b1f11fba0dcc2c22ad8555878cd78a67339f5d183b77f29e0487f75dd64b1db0bb3af426196657662ffbb5caaeb9c843e0bdd997cf5969ff84a4bc",
-        derivationPath: "44'/60'/0'/0/0",
-        derivationMode: "default",
-      },
-      {
-        type: "xPub",
-        currencyId: "bitcoin",
-        name: "Bitcoin 1",
-        xPub: "xpub6BuMJGcTwpMSqqwU4EZVASWw8qd42CsD9HtDHjEJNDYjChiBxzCE9kWHdziQjh1efz3khFCvLBEcKfYMNjB8Xc9vbKvE4p3MgbZFdicGihU",
-        seedId:
-          "04b3b8888ccc77642c07b6361027d2434bf487b38dab43cea16afd1b796d835db42ea6beceb3cec2f29a4177488b205e340bd00e3b78d7a6d89825900aae4dd9b3",
-        derivationPath: "84'/0'/0'/0/0",
-        derivationMode: "native_segwit",
-      },
-    ],
-  );
+  const result = await client.saveData([
+    {
+      id: "js:1:ethereum:0x053A031856b23A823b71e032C92b1599Ac1cc3F2:",
+      currencyId: "ethereum",
+      name: "Ethereum 1",
+      freshAddress: "0x053A031856b23A823b71e032C92b1599Ac1cc3F2",
+      seedIdentifier:
+        "041d35ac3e26b1f11fba0dcc2c22ad8555878cd78a67339f5d183b77f29e0487f75dd64b1db0bb3af426196657662ffbb5caaeb9c843e0bdd997cf5969ff84a4bc",
+      derivationMode: "",
+      index: 0,
+      balance: "0",
+    },
+    {
+      id: "js:2:bitcoin:xpub6D1KvVxAfT1obxiWidB8H7gjQsALwezt4i4CknRsQ7UhCytJw4ZChkrKrdLFjEmA89epjLN5sSeM916shcWbYmSA9cdYjkCx9BzeyJr5yC9:native_segwit",
+      seedIdentifier:
+        "xpub6D1KvVxAfT1obxiWidB8H7gjQsALwezt4i4CknRsQ7UhCytJw4ZChkrKrdLFjEmA89epjLN5sSeM916shcWbYmSA9cdYjkCx9BzeyJr5yC9",
+      name: "Bitcoin native_segwit xpub6D1K...eyJr5yC9",
+      derivationMode: "native_segwit",
+      index: 0,
+      freshAddress: "bc1qe348n4czfyd83jflnzk0eqtazh39wves2zy0x6",
+      currencyId: "bitcoin",
+      balance: "0",
+    },
+  ]);
 
   // eslint-disable-next-line no-console
   console.log("saved data:", result);

--- a/apps/client-test/src/index.ts
+++ b/apps/client-test/src/index.ts
@@ -3,13 +3,13 @@ import "isomorphic-fetch";
 
 async function main() {
   const auth =
-    "aaaaaa00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"; // await generateAuth();
+    "5332dc8d574b9d19a0c61b0b4b94830f13f48c750c5277872980c4032e68170f"; // await generateAuth();
 
   let version: number | undefined;
 
   const client = new WalletSyncClient(
     {
-      url: "http://localhost:3000",
+      url: "https://cloud-sync-backend.aws.stg.ldg-tech.com",
       pollFrequencyMs: 5000,
       auth,
       clientInfo: "test/0.0.1",

--- a/apps/client-test/src/index.ts
+++ b/apps/client-test/src/index.ts
@@ -2,10 +2,8 @@ import { WalletSyncClient } from "@ledgerhq/wss-sdk";
 import "isomorphic-fetch";
 
 async function main() {
-  const auth = Buffer.from(
-    "UzLcjVdLnRmgxhsLS5SDDxP0jHUMUneHKYDEAy5oFw8=",
-    "base64"
-  ); // await generateAuth();
+  const auth =
+    "aaaaaa00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"; // await generateAuth();
 
   let version: number | undefined;
 

--- a/apps/client-test/src/index.ts
+++ b/apps/client-test/src/index.ts
@@ -22,9 +22,9 @@ async function main() {
     }
   );
 
-  client.observable().subscribe((walletData) => {
+  client.observable().subscribe((data) => {
     // eslint-disable-next-line no-console
-    console.log("new wallet data: ", walletData);
+    console.log("new wallet data: ", data);
   });
 
   const result = await client.saveData([

--- a/apps/wss-server/src/MemoryDatabase.ts
+++ b/apps/wss-server/src/MemoryDatabase.ts
@@ -9,8 +9,7 @@ export type Record = {
   ownerId: string;
   version: number;
   payload: string;
-  createdAt: number;
-  updatedAt: number;
+  date: string;
 };
 
 export class MemoryDatabase {
@@ -54,8 +53,7 @@ export class MemoryDatabase {
       ownerId,
       version,
       payload,
-      createdAt: record?.createdAt ?? now,
-      updatedAt: now,
+      date: now.toLocaleString(),
     });
 
     return { status: "updated", version };

--- a/packages/wss-sdk/src/WalletSyncClient.ts
+++ b/packages/wss-sdk/src/WalletSyncClient.ts
@@ -48,11 +48,13 @@ export class WalletSyncClient {
     this._auth = Buffer.from(params.auth, "hex");
     this._params = params;
     this._versionManager = versionManager;
-    this._userId = getUserIdForPrivateKey(params.auth);
+    this._userId = getUserIdForPrivateKey(this._auth);
     this._axios = axios.create({
       baseURL: params.url,
       headers: {
-        // "X-Ledger-Public-Key": params.auth.toString("hex"),
+        "X-Ledger-Public-Key":
+          // FIXME TODO derivated from Auth?
+          "aaaaaa00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
         "X-Ledger-Client-Version": params.clientInfo,
       },
     });
@@ -65,12 +67,17 @@ export class WalletSyncClient {
   private async _poll() {
     const version = this._versionManager.getVersion();
 
-    const rawResponse = await this._axios.get<unknown, unknown>(
-      `/atomic/v1/accounts`,
-      { params: { version } }
-    );
+    const rawResponse = await this._axios.get<unknown>(`/atomic/v1/accounts`, {
+      params: { version },
+      headers: {
+        // TODO set these fields properly in the future
+        "X-Ledger-Timestamp": "2000-01-01T00:00:00.000000000+00:00",
+        "X-Ledger-Signature":
+          "0000000000000000000000000000000000000000000000000000000000000000",
+      },
+    });
 
-    const response = schemaAtomicGetResponse.parse(rawResponse);
+    const response = schemaAtomicGetResponse.parse(rawResponse.data);
 
     // eslint-disable-next-line default-case
     switch (response.status) {
@@ -102,7 +109,7 @@ export class WalletSyncClient {
           "Server has an update: version",
           response.version,
           " updated at ",
-          response.updatedAt,
+          response.date,
           parsedData
         );
         const safeData = schemaWalletDecryptedData.parse(parsedData);
@@ -131,7 +138,7 @@ export class WalletSyncClient {
 
     const newVersion = (version ?? 0) + 1;
 
-    const rawResponse = await this._axios.post<unknown, unknown>(
+    const rawResponse = await this._axios.post<unknown>(
       `/atomic/v1/accounts`,
       {
         payload: rawPayload.toString("base64"),
@@ -141,12 +148,14 @@ export class WalletSyncClient {
           version: newVersion,
         },
         headers: {
-          "X-Ledger-Timestamp": Date.now(),
+          "X-Ledger-Timestamp": "2000-01-01T00:00:00.000000000+00:00",
+          "X-Ledger-Signature":
+            "0000000000000000000000000000000000000000000000000000000000000000",
         },
       }
     );
 
-    const response = schemaAtomicPostResponse.parse(rawResponse);
+    const response = schemaAtomicPostResponse.parse(rawResponse.data);
 
     if (response.status === "updated") {
       this._versionManager.onVersionUpdate(response.version);

--- a/packages/wss-sdk/src/dataTypes/Account/1.0.0/logic.ts
+++ b/packages/wss-sdk/src/dataTypes/Account/1.0.0/logic.ts
@@ -3,13 +3,5 @@ import { AccountMetadata } from "./types";
 import { UUIDV5_NAMESPACE } from "../../../constants";
 
 export function getAccountId(accountMetadata: AccountMetadata) {
-  const aggregatedId = `${
-    accountMetadata.type === "address"
-      ? accountMetadata.address
-      : accountMetadata.xPub
-  }-${accountMetadata.derivationPath}-${accountMetadata.currencyId}-${
-    accountMetadata.derivationMode
-  }`;
-
-  return uuidv5(aggregatedId, UUIDV5_NAMESPACE);
+  return uuidv5(accountMetadata.id, UUIDV5_NAMESPACE);
 }

--- a/packages/wss-sdk/src/dataTypes/Account/1.0.0/schemas.ts
+++ b/packages/wss-sdk/src/dataTypes/Account/1.0.0/schemas.ts
@@ -8,5 +8,4 @@ export const schemaAccountMetadata = z.object({
   derivationMode: z.string(),
   name: z.string(),
   index: z.number(),
-  balance: z.string(),
 });

--- a/packages/wss-sdk/src/dataTypes/Account/1.0.0/schemas.ts
+++ b/packages/wss-sdk/src/dataTypes/Account/1.0.0/schemas.ts
@@ -1,24 +1,12 @@
 import { z } from "zod";
 
-export const schemaAccountMetadataBase = z.object({
-  name: z.string(),
+export const schemaAccountMetadata = z.object({
+  id: z.string(),
   currencyId: z.string(),
-  seedId: z.string(),
-  derivationPath: z.string(),
+  freshAddress: z.string(),
+  seedIdentifier: z.string(),
   derivationMode: z.string(),
+  name: z.string(),
+  index: z.number(),
+  balance: z.string(),
 });
-
-export const schemaAccountMetadataXPub = schemaAccountMetadataBase.extend({
-  type: z.literal("xPub"),
-  xPub: z.string(),
-});
-
-export const schemaAccountMetadataAddress = schemaAccountMetadataBase.extend({
-  type: z.literal("address"),
-  address: z.string(),
-});
-
-export const schemaAccountMetadata = z.discriminatedUnion("type", [
-  schemaAccountMetadataXPub,
-  schemaAccountMetadataAddress,
-]);

--- a/packages/wss-sdk/src/dataTypes/schemas.ts
+++ b/packages/wss-sdk/src/dataTypes/schemas.ts
@@ -1,6 +1,4 @@
 import { z } from "zod";
 import { schemaAccountMetadata } from "./Account/1.0.0/schemas";
 
-export const schemaWalletDecryptedData = z.object({
-  accounts: z.array(schemaAccountMetadata),
-});
+export const schemaWalletDecryptedData = z.array(schemaAccountMetadata);

--- a/packages/wss-shared/src/types/api/schemas.ts
+++ b/packages/wss-shared/src/types/api/schemas.ts
@@ -19,8 +19,7 @@ export const schemaAtomicGetOutOfSync = z.object({
   status: z.literal("out-of-sync"),
   version: z.number(),
   payload: z.string(),
-  createdAt: z.number(),
-  updatedAt: z.number(),
+  date: z.string(),
   info: z.string().optional(),
 });
 export const schemaAtomicGetResponse = z.discriminatedUnion("status", [
@@ -41,8 +40,7 @@ export const schemaAtomicPostOutOfSync = z.object({
   status: z.literal("out-of-sync"),
   version: z.number(),
   payload: z.string(),
-  createdAt: z.number(),
-  updatedAt: z.number(),
+  date: z.string(),
   info: z.string().optional(),
 });
 export const schemaAtomicPostResponse = z.discriminatedUnion("status", [
@@ -54,8 +52,7 @@ export const schemaAtomicPostResponse = z.discriminatedUnion("status", [
 export const schemaIncrementalUpdate = z.object({
   version: z.number(),
   payload: z.string(),
-  createdAt: z.number(),
-  updatedAt: z.number(),
+  date: z.string(),
   info: z.string().optional(),
 });
 

--- a/packages/wss-shared/src/types/schemas.ts
+++ b/packages/wss-shared/src/types/schemas.ts
@@ -5,8 +5,7 @@ export const schemaEncryptedClientData = z.object({
   ownerId: z.string(),
   dataTypeId: z.number(),
   encryptedData: z.string(),
-  createdAt: z.number(),
-  updatedAt: z.number(),
+  date: z.string(),
 });
 
 export type EncryptedClientData = z.infer<typeof schemaEncryptedClientData>;


### PR DESCRIPTION
## Move Account data type to AccountData from live-common

This simplify the type model in order to add necessary fields that will be needed to properly sign transactions on the imported accounts.

For instance:
- we need the derivation index to be able to properly rebuild `freshAddressPath`. On the other end, having the freshAddressPath in the export can't be stable for bitcoin like accounts (it changes over receives)
- we need the `id` because a coin may decide that it contains extra key to synchronise the account. This is the case of Bitcoin to put the xpub in the id itself. We shouldn't have to recreate an id on Live side when we can simply export it as is. It is also the case of Tezos that exports the "revealed key" on the account id in order to later sign transactions (it is not the public address).

more reasons has been discussed in https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/4248043754/Wallet+Sync+PoC+with+Full+Sync and generally speaking, this direction will allow to reuse more logic on Ledger Live side, since we will be able to fully reuse our existing logic of `cross.ts` (we took the exact same type here).

## Change the signature of observable to emit [data,version]

with the fact the observable() events can't be treated synchronously anymore, we have to make the "version set" to be committed at the same time as the data to be effectively handled by the client, in that sense it makes more sense for version to be emitted within the data and it's responsability of the user land to do the update.

with that direction, i wonder if we still the "version manager" at all. the sdk logic starts to mix with the live-common's so i'm not sure if this PR changes are stable yet. we'll need to iterate on https://github.com/LedgerHQ/ledger-live/pull/4352 which have embedded wss-sdk there for now

## WalletSyncClient to take a auth:string instead of cryptic Buffer

Ledger Live instances are going to need to store this as a string, so it was simpler to just pass it through without having to keep the Buffer conversion on user land 🤔 . but happy to discuss this if it's a problem.

## Fix API usage, schema and connect auth to it

directly coming from #16 

## Another feedback (no changes made on the PR on this)

I recommend that this library don't log anything. most of the logs i have seen are not useful, we don't need the low level logs because we actually can see them on the networking stack already. however, the reconciliation logs on live-common are more useful, higher level, and it makes this lib's log too verbose / redundant.

on top of this, the current Logger don't work on the web. it uses `process.env` which will break with "process is not defined".

so i would recommend to remove completely the logger. OR if you need a logger, just use `@ledgerhq/logs`