### PR TITLE
Switch to stg backend, add valid credentials, fix schema mismatches

### DIFF
--- a/apps/client-test/src/index.ts
+++ b/apps/client-test/src/index.ts
@@ -10,7 +10,7 @@ async function main() {
   let version: number | undefined;
 
   const client = new WalletSyncClient({
-    url: "http://localhost:3000",
+    url: "https://cloud-sync-backend.aws.stg.ldg-tech.com",
     pollFrequencyMs: 5000,
     auth,
     clientInfo: "test/0.0.1"

--- a/apps/wss-server/src/MemoryDatabase.ts
+++ b/apps/wss-server/src/MemoryDatabase.ts
@@ -9,8 +9,7 @@ export type Record = {
   ownerId: string;
   version: number;
   payload: string;
-  createdAt: number;
-  updatedAt: number;
+  date: string;
 };
 
 export class MemoryDatabase {
@@ -54,8 +53,7 @@ export class MemoryDatabase {
       ownerId,
       version,
       payload,
-      createdAt: record?.createdAt ?? now,
-      updatedAt: now,
+      date: now.toLocaleString(),
     });
 
     return { status: "updated", version };

--- a/packages/wss-sdk/src/WalletSyncClient.ts
+++ b/packages/wss-sdk/src/WalletSyncClient.ts
@@ -49,7 +49,9 @@ export class WalletSyncClient {
     this._axios = axios.create({
       baseURL: params.url,
       headers: {
-        // "X-Ledger-Public-Key": params.auth.toString("hex"),
+        "X-Ledger-Public-Key": "aaaaaa00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+        "X-Ledger-Timestamp": "2000-01-01T00:00:00.000000000+00:00",
+        "X-Ledger-Signature": "0000000000000000000000000000000000000000000000000000000000000000",
         "X-Ledger-Client-Version": params.clientInfo,
       },
     });

--- a/packages/wss-sdk/src/WalletSyncClient.ts
+++ b/packages/wss-sdk/src/WalletSyncClient.ts
@@ -50,8 +50,6 @@ export class WalletSyncClient {
       baseURL: params.url,
       headers: {
         "X-Ledger-Public-Key": "aaaaaa00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
-        "X-Ledger-Timestamp": "2000-01-01T00:00:00.000000000+00:00",
-        "X-Ledger-Signature": "0000000000000000000000000000000000000000000000000000000000000000",
         "X-Ledger-Client-Version": params.clientInfo,
       },
     });
@@ -66,7 +64,15 @@ export class WalletSyncClient {
 
     const rawResponse = await this._axios.get<unknown, unknown>(
       `/atomic/v1/accounts`,
-      { params: { version } }
+      {
+        params: {
+          version
+        },
+        headers: {
+          "X-Ledger-Timestamp": '2000-01-01T00:00:00.000000000+00:00',
+          "X-Ledger-Signature": "0000000000000000000000000000000000000000000000000000000000000000",
+        }
+      }
     );
 
     const response = schemaAtomicGetResponse.parse(rawResponse);
@@ -144,7 +150,8 @@ export class WalletSyncClient {
           version: newVersion,
         },
         headers: {
-          "X-Ledger-Timestamp": Date.now(),
+          "X-Ledger-Timestamp": '2000-01-01T00:00:00.000000000+00:00',
+          "X-Ledger-Signature": "0000000000000000000000000000000000000000000000000000000000000000",
         },
       }
     );

--- a/packages/wss-sdk/src/WalletSyncClient.ts
+++ b/packages/wss-sdk/src/WalletSyncClient.ts
@@ -62,6 +62,8 @@ export class WalletSyncClient {
   private async _poll() {
     const version = this._versionManager.getVersion();
 
+    console.log("polling...");
+
     const rawResponse = await this._axios.get<unknown, unknown>(
       `/atomic/v1/accounts`,
       {
@@ -75,7 +77,8 @@ export class WalletSyncClient {
       }
     );
 
-    const response = schemaAtomicGetResponse.parse(rawResponse);
+    // @ts-ignore
+    const response = schemaAtomicGetResponse.parse(rawResponse.data);
 
     // eslint-disable-next-line default-case
     switch (response.status) {
@@ -111,7 +114,7 @@ export class WalletSyncClient {
           "Server has an update: version",
           response.version,
           " updated at ",
-          response.updatedAt,
+          response.date,
           parsedData
         );
         const safeData = schemaWalletDecryptedData.parse(parsedData);
@@ -156,7 +159,8 @@ export class WalletSyncClient {
       }
     );
 
-    const response = schemaAtomicPostResponse.parse(rawResponse);
+    // @ts-ignore
+    const response = schemaAtomicPostResponse.parse(rawResponse.data);
 
     if (response.status === "updated") {
       this._versionManager.onVersionUpdate(response.version);

--- a/packages/wss-sdk/src/dataTypes/schemas.ts
+++ b/packages/wss-sdk/src/dataTypes/schemas.ts
@@ -1,6 +1,4 @@
 import { z } from "zod";
 import { schemaAccountMetadata } from "./Account/1.0.0/schemas";
 
-export const schemaWalletDecryptedData = z.object({
-  accounts: z.array(schemaAccountMetadata),
-});
+export const schemaWalletDecryptedData = z.array(schemaAccountMetadata);

--- a/packages/wss-shared/src/types/api/schemas.ts
+++ b/packages/wss-shared/src/types/api/schemas.ts
@@ -19,8 +19,7 @@ export const schemaAtomicGetOutOfSync = z.object({
   status: z.literal("out-of-sync"),
   version: z.number(),
   payload: z.string(),
-  createdAt: z.number(),
-  updatedAt: z.number(),
+  date: z.string(),
   info: z.string().optional(),
 });
 export const schemaAtomicGetResponse = z.discriminatedUnion("status", [
@@ -41,8 +40,7 @@ export const schemaAtomicPostOutOfSync = z.object({
   status: z.literal("out-of-sync"),
   version: z.number(),
   payload: z.string(),
-  createdAt: z.number(),
-  updatedAt: z.number(),
+  date: z.string(),
   info: z.string().optional(),
 });
 export const schemaAtomicPostResponse = z.discriminatedUnion("status", [
@@ -54,8 +52,7 @@ export const schemaAtomicPostResponse = z.discriminatedUnion("status", [
 export const schemaIncrementalUpdate = z.object({
   version: z.number(),
   payload: z.string(),
-  createdAt: z.number(),
-  updatedAt: z.number(),
+  date: z.string(),
   info: z.string().optional(),
 });
 

--- a/packages/wss-shared/src/types/schemas.ts
+++ b/packages/wss-shared/src/types/schemas.ts
@@ -5,8 +5,7 @@ export const schemaEncryptedClientData = z.object({
   ownerId: z.string(),
   dataTypeId: z.number(),
   encryptedData: z.string(),
-  createdAt: z.number(),
-  updatedAt: z.number(),
+  date: z.string(),
 });
 
 export type EncryptedClientData = z.infer<typeof schemaEncryptedClientData>;


### PR DESCRIPTION
Main loop working with staging backend:
```
❯ pnpm run start:dev 

> @ledgerhq/client-test@1.1.0 start:dev /home/jnicoulaud/work/ledger/backend/cloud-sync/wallet-sync-system/apps/client-test
> npx nodemon

[nodemon] 2.0.22
[nodemon] to restart at any time, enter `rs`
[nodemon] watching path(s): src/**/*
[nodemon] watching extensions: ts,js
[nodemon] starting `npx ts-node ./src/index.ts`
saved data: {
  status: 'out-of-sync',
  version: 1,
  payload: '+FiXlH0f5uDDQmWX6bju5NbaKTmrDu7MLxrW2fiXRVaiEpjxRi5mkHHCgovBAM1a0XSTcOFQ1qpo0kc1NEqrHtI6/7x69i3AihyNrOyouj5phfYRP1R9anCrYfG9CulebjwnFQ3MgRtz+xQMWwZpkvgdt+oQvT/BgWjs67vZ9RsQMLg7BdaV9uSQ80akBWiqPS05n5HZHYt324S7S7FGalr1VxtPig72RZFp2Uufn3LmaxqOHb9CVlHVJ5g3jkIl4PA+ZD4UxW+YsuDaU1m6Aeyiw4MBcJHQd2Gd5EdhqafsBOQclGJKpNtfXRtpcbIyXM/8NImyr5w3ItDGrMok/t5RrKRsfdnZFLlCYqsQcizVk43f/aNUlmYB5cmp5hZrGLtWxRbJJh5FuJaQ6L4QFnwyU3I0yt49vQqzL6SJJGSjXxFOnndR5FyK288WYNfSa79QM6uXEakJ9CLZ1j/vCH7bTZKO2/SQIVjlXDD+/TvhvzPz/Et3yBAQ4NXoKhPlTyw2/ZI8Vw0XMEcyQTNQeHM8UgQMn6l2K+06NDEq0aJney+hfC0p8bMoKCskfuslsUoU3+UknIXyExg4TNCb9VjdJApCX1uFcM4xuDSRA3GrCYEGCy44A+g2RXmSY7T/aevmzRkW7+ZJLsGh5nlIjgXsGr7q+0zqGPboRjSBbDtWEx9ZaYAEtwrKxrFdCCX9FjxeLLfyzf2adMPZK1NUf+xv+76WLS88aIH2U+IpNv4v6fCd4EzJfDVe5Euz90ZWnR4SEFn8RzzTBivCbq1fIFVc34Wy+8WF3dXI8t8SMNpsARqa/tSZo6xh0wOo0pgbLWq1C70MnYehZtVDVymxp7djsBivzjgYcJsab3KBsyIPvdFaRMgmIlPCRU/kN9EMNGUSe7RIcq0Jskg0+sBkZSsEdpNlZ0KV8OWMWRLoH9jmRo2SkuDJ4gBwKrIrr96hNW9pijBQ9dZ6LkT3aedPAA==',
  date: '2023-08-17T15:01:25.068042Z',
  info: 'test/0.0.1'
}
polling...
Server has an update: version 1  updated at  2023-08-17T15:01:25.068042Z [
  {
    type: 'address',
    currencyId: 'ethereum',
    name: 'Ethereum 1',
    address: '0x053A031856b23A823b71e032C92b1599Ac1cc3F2',
    seedId: '041d35ac3e26b1f11fba0dcc2c22ad8555878cd78a67339f5d183b77f29e0487f75dd64b1db0bb3af426196657662ffbb5caaeb9c843e0bdd997cf5969ff84a4bc',
    derivationPath: "44'/60'/0'/0/0",
    derivationMode: 'default'
  },
  {
    type: 'xPub',
    currencyId: 'bitcoin',
    name: 'Bitcoin 1',
    xPub: 'xpub6BuMJGcTwpMSqqwU4EZVASWw8qd42CsD9HtDHjEJNDYjChiBxzCE9kWHdziQjh1efz3khFCvLBEcKfYMNjB8Xc9vbKvE4p3MgbZFdicGihU',
    seedId: '04b3b8888ccc77642c07b6361027d2434bf487b38dab43cea16afd1b796d835db42ea6beceb3cec2f29a4177488b205e340bd00e3b78d7a6d89825900aae4dd9b3',
    derivationPath: "84'/0'/0'/0/0",
    derivationMode: 'native_segwit'
  }
]
new wallet data:  [
  {
    name: 'Ethereum 1',
    currencyId: 'ethereum',
    seedId: '041d35ac3e26b1f11fba0dcc2c22ad8555878cd78a67339f5d183b77f29e0487f75dd64b1db0bb3af426196657662ffbb5caaeb9c843e0bdd997cf5969ff84a4bc',
    derivationPath: "44'/60'/0'/0/0",
    derivationMode: 'default',
    type: 'address',
    address: '0x053A031856b23A823b71e032C92b1599Ac1cc3F2'
  },
  {
    name: 'Bitcoin 1',
    currencyId: 'bitcoin',
    seedId: '04b3b8888ccc77642c07b6361027d2434bf487b38dab43cea16afd1b796d835db42ea6beceb3cec2f29a4177488b205e340bd00e3b78d7a6d89825900aae4dd9b3',
    derivationPath: "84'/0'/0'/0/0",
    derivationMode: 'native_segwit',
    type: 'xPub',
    xPub: 'xpub6BuMJGcTwpMSqqwU4EZVASWw8qd42CsD9HtDHjEJNDYjChiBxzCE9kWHdziQjh1efz3khFCvLBEcKfYMNjB8Xc9vbKvE4p3MgbZFdicGihU'
  }
]







polling...

Up to date
```